### PR TITLE
Add run-relayer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenZeppelin GSN Helpers
 
-**Test and development helper methods and scripts for using the Gas Station Network.** Provides methods for quickly deploying a relay hub, funding a recipient, or registering a relayer (the last based on [fundrelay.js](https://github.com/tabookey/tabookey-gasless/blob/master/scripts/fundrelay.js) from `tabookey-gasless`).
+**Test and development helper methods and scripts for using the Gas Station Network.** Provides methods for quickly running a relayer, deploying a relay hub, funding a recipient, or registering a relayer (the last based on [fundrelay.js](https://github.com/tabookey/tabookey-gasless/blob/master/scripts/fundrelay.js) from `tabookey-gasless`).
 
 ## Install
 
@@ -11,9 +11,36 @@ npm install @openzeppelin/gsn-helpers
 ## Features
 
 This suite has helper methods and command line scripts to:
+- Run a relayer process
 - Deploy a new relay hub
 - Register a relayer in the hub
 - Fund a recipient contract in the hub
+
+## Running the relayer binary
+
+You can use the `npx oz-gsn run-relayer` command to automatically download a relayer binary for your current platform and start it. Before starting the relayer process, this command also deploys a relay hub to the current network (if there isn't one already), and then registers the relayer on it.
+
+```bash
+$ npx oz-gsn run-relayer --quiet
+Deploying singleton RelayHub instance
+RelayHub deployed at 0xd216153c06e857cd7f72665e0af1d7d82172f494
+Downloading relayer from https://github.com/OpenZeppelin/openzeppelin-gsn-helpers/releases/download/v0.1.4/gsn-relay-linux-amd64
+Relayer downloaded to ~/.gsn/gsn-relay-v0.1.4
+Starting relayer
+~/.gsn/gsn-relay-v0.1.4  
+ -EthereumNodeUrl http://localhost:8545
+ -RelayHubAddress 0xd216153c06e857cd7f72665e0af1d7d82172f494
+ -Port 8090
+ -Url http://localhost:8090
+ -GasPricePercent 0
+ -Workdir /tmp/tmp-95095UJ2M2Pfw0xi
+ -DevMode
+Funding GSN relay at http://localhost:8090
+Will wait up to 30s for the relay to be ready
+Relay is funded and ready!
+```
+
+You can pass in the `--detach` option if you want to the process to exit after the relay is ready to use. This is useful to setup an ephemeral relayer for testing purposes. The command will output the PID of the relayer subprocess, so you can kill it afterwards (see _Sample testing setup_ below).
 
 ## Usage from code
 
@@ -26,6 +53,18 @@ const web3 = new Web3(...);
 // Deploy a relay hub instance
 await deployRelayHub(web3, {
   from: accounts[0]
+});
+
+// Download the platform-specific binary and run a relayer
+await runRelayer({
+  relayUrl: 'http://localhost:8090',
+  relayHubAddress: '0xd216153c06e857cd7f72665e0af1d7d82172f494',
+  workdir: process.cwd(), // defaults to tmp dir
+  devMode: true,
+  ethereumNodeURL: 'http://localhost:8545',
+  gasPricePercent: 0,
+  port: 8090,
+  quiet: true
 });
 
 // Register a relayer in the hub, requires the relayer process to be running
@@ -60,6 +99,7 @@ Options:
   -h, --help        output usage information
 
 Commands:
+  run-relayer       downloads and runs a relayer binary, and registers it, deploying a hub if needed
   deploy-relay-hub  deploy the singleton RelayHub instance
   register-relayer  stake for a relayer and fund it
   fund-recipient    fund a recipient contract so that it can receive relayed calls
@@ -68,7 +108,49 @@ Commands:
 
 ## Sample testing setup
 
-You can use the `oz-gsn` command line helpers to deploy a relay hub, spin up a relayer, and register it on your testing setup. Make sure to donwload the relayer binary to run it locally:
+You can use the `oz-gsn` command line helpers to download the relayer binary, deploy a relay hub, spin up a relayer, and register it on your testing setup:
+
+```bash
+trap cleanup EXIT
+
+cleanup() {
+  kill $gsn_relay_server_pid
+}
+
+ganache_url="http://localhost:$ganache_port"
+relayer_port=8099
+
+setup_gsn_relay() {
+  gsn_relay_server_pid=$(npx oz-gsn run-relayer --ethereumNodeURL $ganache_url --port $relayer_port --detach --quiet)
+}
+```
+
+Then, on your tests, you only need to set up a GSN provider and register any recipients:
+
+```js
+beforeEach('setup', async function () {
+  // Create web3 instance and a contract
+  this.web3 = new Web3(PROVIDER_URL);
+  this.accounts = await this.web3.eth.getAccounts();
+
+  // Create recipient contract
+  const Recipient = new this.web3.eth.Contract(RecipientAbi, null, { data: RecipientBytecode });
+  this.recipient = await Recipient.deploy().send({ from: this.accounts[0], gas: 1e6 });
+
+  // Register the recipient in the hub
+  await fundRecipient(this.web3, { recipient: this.recipient.options.address });
+  
+  // Create gsn provider and plug it into the recipient
+  const gsnProvider = new GSNProvider(PROVIDER_URL);
+  this.recipient.setProvider(gsnProvider);
+});
+```
+
+All transactions sent to the `recipient` contract instance will be sent as a meta-transaction via the GSN running locally on your workstation.
+
+### Advanced setup
+
+If you prefer more fine-grained control over the recipient setup, or running a custom relayer binary, you can use the following setup:
 
 ```bash
 ganache_url="http://localhost:8545"
@@ -94,27 +176,6 @@ setup_gsn_relay() {
   npx oz-gsn register-relayer --ethereumNodeURL $ganache_url --relayUrl $relayer_url
 }
 ```
-
-Then, on your tests, you only need to set up a GSN provider and register any recipients:
-
-```js
-beforeEach(async function () {
-  // Create web3 instance and a contract
-  this.web3 = new Web3(PROVIDER_URL);
-  this.accounts = await this.web3.eth.getAccounts();
-  const Recipient = new this.web3.eth.Contract(RecipientAbi, null, { data: RecipientBytecode });
-  this.recipient = await Recipient.deploy().send({ from: this.accounts[0], gas: 1e6 });
-  
-  // Register the recipient in the hub
-  await fundRecipient(this.web3, { recipient: this.recipient.options.address });
-  
-  // Create gsn provider and plug it into the recipient
-  const gsnProvider = new GSNProvider(PROVIDER_URL);
-  this.recipient.setProvider(gsnProvider);
-});
-```
-
-All transactions sent to the `recipient` contract instance will be sent as a meta-transaction via the GSN running locally on your workstation.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 const { registerRelay, deployRelayHub, fundRecipient, getRelayHub } = require('./src/helpers');
 const { relayHub } = require('./src/data');
+const { runRelayer, runAndRegister } = require('./src/run');
+const { downloadRelayer } = require('./src/download');
 const expectError = require('./src/expectError');
 const _ = require('lodash');
 
@@ -9,5 +11,8 @@ module.exports = {
   fundRecipient,
   getRelayHub,
   expectError,
-  relayHub: _.pick(relayHub, ['abi', 'address', 'bytecode'])
+  relayHub: _.pick(relayHub, ['abi', 'address', 'bytecode']),
+  runRelayer,
+  runAndRegister,
+  downloadRelayer
 };

--- a/oz-gsn-deploy-relay-hub.js
+++ b/oz-gsn-deploy-relay-hub.js
@@ -12,4 +12,5 @@ const Web3 = require('web3');
 const web3 = new Web3(nodeURL);
 
 const { deployRelayHub } = require('./src/helpers');
-deployRelayHub(web3, lodash.pick(program, ['from']));
+deployRelayHub(web3, lodash.pick(program, ['from']))
+  .then(address => console.log(address));

--- a/oz-gsn-run-relayer.js
+++ b/oz-gsn-run-relayer.js
@@ -5,7 +5,7 @@ const process = require('process');
 program
   .option('-n, --ethereumNodeURL <url>', 'url to the local Ethereum node', 'http://localhost:8545')
   .option('--relayUrl <url>', 'url to advertise the relayer (defaults to localhost:8090)')
-  .option('-p, --port <port>', 'port to bind the relayer to (defaults to url port)')
+  .option('-p, --port <port>', 'port to bind the relayer to (defaults to port defined in url)')
   .option('--relayHubAddress <address>', 'address to the relay hub (deploys a new hub if not set)')
   .option('-f, --from <account>', 'account to send transactions from (defaults to first account with balance)')
   .option('--workdir <workdir>', 'working directory for relayer data (defaults to tmp dir)')
@@ -17,6 +17,10 @@ program
 
 const { runRelay, runAndRegister } = require('./src/run');
 const opts = lodash.pick(program, ['detach', 'workdir', 'ethereumNodeURL', 'relayUrl', 'port', 'relayHubAddress', 'from', 'devMode', 'quiet']);
+if (opts.port && opts.relayUrl) {
+  console.error(`Cannot set both port and relayUrl options. Please set only one.`);
+  process.exit(1);
+}
 
 if (program.register === false) {
   runRelay(opts);

--- a/oz-gsn-run-relayer.js
+++ b/oz-gsn-run-relayer.js
@@ -1,0 +1,39 @@
+const program = require('commander');
+const lodash = require('lodash');
+const process = require('process');
+
+program
+  .option('-n, --ethereumNodeURL <url>', 'url to the local Ethereum node', 'http://localhost:8545')
+  .option('--relayUrl <url>', 'url to advertise the relayer (defaults to localhost:8090)')
+  .option('-p, --port <port>', 'port to bind the relayer to (defaults to url port)')
+  .option('--relayHubAddress <address>', 'address to the relay hub (deploys a new hub if not set)')
+  .option('-f, --from <account>', 'account to send transactions from (defaults to first account with balance)')
+  .option('--workdir <workdir>', 'working directory for relayer data (defaults to tmp dir)')
+  .option('-q, --quiet', 'silence relayer process output')
+  .option('-d, --detach', 'exit process after relayer is ready, and return relayer process pid, but remember to kill it yourself! (implies --quiet)')
+  .option('--no-register', 'skip registration of the relayer process')
+  .option('--no-devMode', 'turns off dev mode in relayer')
+  .parse(process.argv);
+
+const { runRelay, runAndRegister } = require('./src/run');
+const opts = lodash.pick(program, ['detach', 'workdir', 'ethereumNodeURL', 'relayUrl', 'port', 'relayHubAddress', 'from', 'devMode', 'quiet']);
+
+if (program.register === false) {
+  runRelay(opts);
+  return;
+}
+
+const Web3 = require('web3');
+const web3 = new Web3(program.ethereumNodeURL);
+
+web3.eth.getAccounts()
+  .then(async () => { 
+    const subprocess = await runAndRegister(web3, opts);
+    if (program.detach) {
+      subprocess.unref();
+      process.exit(0);
+    }
+  })
+  .catch(err => { 
+    console.error(`Could not connect to node at ${program.ethereumNodeURL} (${err}).`); 
+  });

--- a/oz-gsn.js
+++ b/oz-gsn.js
@@ -4,7 +4,8 @@ const program = require('commander');
 
 program
   .version(require('./package.json').version)
-  .command('deploy-relay-hub', 'deploy the singleton RelayHub instance')
+  .command('run-relayer', 'downloads and runs a relayer binary, and registers it, deploying a hub if needed')
+  .command('deploy-relay-hub', 'deploy the singleton relay hub instance')
   .command('register-relayer', 'stake for a relayer and fund it')
   .command('fund-recipient', 'fund a recipient contract so that it can receive relayed calls')
   .parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,11 +1848,11 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
-      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "requires": {
-        "graceful-fs": "^4.1.2",
+        "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
       }
@@ -4229,6 +4229,14 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -4763,6 +4771,16 @@
         "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "get-stream": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -4869,6 +4887,14 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "requires": {
+        "rimraf": "^2.6.3"
+      }
     },
     "to-absolute-glob": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1272,6 +1272,11 @@
         "once": "^1.4.0"
       }
     },
+    "env-paths": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "commander": "^2.20.0",
+    "env-paths": "^2.2.0",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",
     "sleep-promise": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
     "axios": "^0.19.0",
     "chai": "^4.2.0",
     "commander": "^2.20.0",
+    "fs-extra": "^8.1.0",
     "lodash": "^4.17.15",
     "sleep-promise": "^8.0.1",
+    "tmp": "^0.1.0",
     "web3": "^1.2.1"
   },
   "peerDependencies": {

--- a/src/download.js
+++ b/src/download.js
@@ -1,5 +1,5 @@
 const process = require('process');
-const homedir = require('os').homedir();
+const envPaths = require('env-paths');
 const { createWriteStream, chmodSync } = require('fs');
 const { pathExists, ensureDir } = require('fs-extra');
 const { dirname } = require('path');
@@ -8,7 +8,7 @@ const axios = require('axios');
 const REPOSITORY = 'OpenZeppelin/openzeppelin-gsn-helpers';
 const VERSION = 'v0.1.4';
 const BINARY = 'gsn-relay';
-const PATH = `${homedir}/.gsn/${BINARY}-${VERSION}`;
+const PATH = `${envPaths('gsn').cache}/${BINARY}-${VERSION}`;
 
 async function ensureRelayer(path=PATH) {
   if (await hasRelayer(path)) return path;

--- a/src/download.js
+++ b/src/download.js
@@ -1,0 +1,66 @@
+const process = require('process');
+const homedir = require('os').homedir();
+const { createWriteStream, chmodSync } = require('fs');
+const { pathExists, ensureDir } = require('fs-extra');
+const { dirname } = require('path');
+const axios = require('axios');
+
+const REPOSITORY = 'OpenZeppelin/openzeppelin-gsn-helpers';
+const VERSION = 'v0.1.4';
+const BINARY = 'gsn-relay';
+const PATH = `${homedir}/.gsn/${BINARY}-${VERSION}`;
+
+async function ensureRelayer(path=PATH) {
+  if (await hasRelayer(path)) return path;
+  await downloadRelayer(path);
+  return path;
+}
+
+async function hasRelayer(path=PATH) {
+  return await pathExists(path);
+}
+
+async function downloadRelayer(path=PATH) {
+  await ensureDir(dirname(path));
+  const url = getUrl();
+  const writer = createWriteStream(path);
+  console.error(`Downloading relayer from ${url}`);
+  const response = await axios.get(url, { responseType: 'stream' });
+  response.data.pipe(writer);
+  
+  await new Promise((resolve, reject) => {
+    writer.on('finish', resolve);
+    writer.on('error', reject);
+  });
+
+  console.error(`Relayer downloaded to ${path}`);
+  chmodSync(path, '775');
+}
+
+function getUrl() {
+  return `https://github.com/${REPOSITORY}/releases/download/${VERSION}/${BINARY}-${getPlatform()}-${getArch()}`
+}
+
+function getPlatform() {
+  switch(process.platform) {
+    case 'win32': return 'windows';
+    default: return process.platform;
+  }
+}
+
+function getArch() {
+  switch(process.arch) {
+    case 'x64': return 'amd64';
+    case 'x32': return '386';
+    case 'ia32': return '386';
+    default: return process.arch;
+  }
+}
+
+function getPath() {
+  return PATH;
+}
+
+module.exports = {
+  ensureRelayer, downloadRelayer, hasRelayer, getUrl, getPath
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,7 @@ const data = require('./data');
 const axios = require('axios');
 const sleep = require('sleep-promise');
 const utils = require('web3').utils;
+const { merge } = require('lodash');
 
 const ether = function(value) {
   return new utils.BN(utils.toWei(value, 'ether'));
@@ -40,6 +41,7 @@ async function registerRelay(web3, relayUrl, relayHubAddress, stake, unstakeDela
 
 async function deployRelayHub(web3, from) {
   if ((await web3.eth.getCode(data.relayHub.address)).length > '0x0'.length) {
+    console.error(`RelayHub already deployed at ${data.relayHub.address}`)
     return data.relayHub.address;
   }
 
@@ -48,8 +50,7 @@ async function deployRelayHub(web3, from) {
 
   await web3.eth.sendSignedTransaction(data.relayHub.deploy.tx);
 
-  console.error(`RelayHub deployed!`);
-  console.log(data.relayHub.address);
+  console.error(`RelayHub deployed at ${data.relayHub.address}`);
 
   return data.relayHub.address;
 }
@@ -115,7 +116,7 @@ module.exports = {
       from: await defaultFromAccount(web3, options && options.from),
     };
 
-    options = { ...defaultOptions, ... options};
+    options = merge(defaultOptions, options);
 
     await registerRelay(web3, options.relayUrl, options.relayHubAddress, options.stake, options.unstakeDelay, options.funds, options.from);
   },
@@ -125,9 +126,9 @@ module.exports = {
       from: await defaultFromAccount(web3, options && options.from),
     };
 
-    options = { ...defaultOptions, ... options};
+    options = merge(defaultOptions, options);
 
-    await deployRelayHub(web3, options.from);
+    return await deployRelayHub(web3, options.from);
   },
 
   fundRecipient: async function (web3, options = {}) {
@@ -137,7 +138,7 @@ module.exports = {
       relayHubAddress: data.relayHub.address
     };
 
-    options = { ...defaultOptions, ... options};
+    options = merge(defaultOptions, options);
 
     await fundRecipient(web3, options.recipient, options.amount, options.from, options.relayHubAddress);
   },

--- a/src/run.js
+++ b/src/run.js
@@ -1,0 +1,76 @@
+const { spawn } = require('child_process');
+const { ensureRelayer } = require('./download');
+const { relayHub } = require('./data');
+const { deployRelayHub, registerRelay } = require('./helpers');
+const sleep = require('sleep-promise');
+const tmp = require('tmp');
+const { chunk } = require('lodash');
+
+async function runRelayer({ detach, workdir, devMode, ethereumNodeURL, gasPricePercent, port, relayUrl, relayHubAddress, quiet }) {
+  // Download relayer if needed
+  const binPath = await ensureRelayer();
+
+  // Create tmp dir
+  const workingDir = workdir || tmp.dirSync({ unsafeCleanup: true }).name;
+
+  // Build args
+  const args = [];
+  if (ethereumNodeURL) args.push('-EthereumNodeUrl', ethereumNodeURL);
+  if (relayHubAddress) args.push('-RelayHubAddress', relayHubAddress);
+  args.push('-Port', getPort({ relayUrl, port }));
+  args.push('-Url', getUrl({ relayUrl, port }));
+  args.push('-GasPricePercent', gasPricePercent || 0);
+  args.push('-Workdir', workingDir);
+  if (devMode !== false) args.push('-DevMode');
+  
+  // Run it!
+  console.error(`Starting relayer\n${binPath}\n${chunk(args, 2).map(arr => ' ' + arr.join(' ')).join('\n')}`);
+  return spawn(binPath, args, {
+    stdio: (quiet || detach) ? 'ignore' : 'inherit',
+    detached: !!detach
+  });
+}
+
+async function runAndRegister(web3, opts={}) {
+  const { from } = opts;
+  let { relayHubAddress } = opts;
+
+  // Deploy relay hub if needed
+  if (!relayHubAddress || relayHubAddress === relayHub.address) {
+    relayHubAddress = await deployRelayHub(web3, { from });
+  }
+
+  // Start running relayer and register it
+  const process = await runRelayer({ ...opts, relayHubAddress });
+  await sleep(2000);
+  try {
+    await registerRelay(web3, { relayHubAddress, from, relayUrl: getUrl(opts) });
+  } catch (err) {
+    process.kill();
+    throw err;
+  }
+
+  return process;
+}
+
+function getUrl({ relayUrl, port }) {
+  if (relayUrl) return relayUrl;
+  if (port) return `http://localhost:${port}`;
+  return 'http://localhost:8090';
+}
+
+function getPort({ relayUrl, port }) {
+  if (port) return port;
+  if (relayUrl) {
+    const url = new URL(relayUrl);
+    if (url.port.length > 0) return url.port;
+    else if (url.protocol === 'https') return 443;
+    else return 80;
+  }
+  return 8090;
+}
+
+module.exports = {
+  runRelayer,
+  runAndRegister
+}

--- a/src/run.js
+++ b/src/run.js
@@ -41,16 +41,16 @@ async function runAndRegister(web3, opts={}) {
   }
 
   // Start running relayer and register it
-  const process = await runRelayer({ ...opts, relayHubAddress });
+  const subprocess = await runRelayer({ ...opts, relayHubAddress });
   await sleep(2000);
   try {
     await registerRelay(web3, { relayHubAddress, from, relayUrl: getUrl(opts) });
   } catch (err) {
-    process.kill();
+    subprocess.kill();
     throw err;
   }
 
-  return process;
+  return subprocess;
 }
 
 function getUrl({ relayUrl, port }) {


### PR DESCRIPTION
Adds a oz-gsn run-relayer command. It downloads the relayer binary from a github release to the home folder, deploys the relay hub contract, starts the relayer process, registers the relayer on the hub, and funds it. It can be called with a `--detach` flag so it exits after the setup is ready, so it can be used for test setup.

Fixes #7 